### PR TITLE
Upgrade to phoenix 0.12.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PhoenixTokenAuth.Mixfile do
 
   def project do
     [app: :phoenix_token_auth,
-     version: "0.0.7",
+     version: "0.0.7-kal",
      elixir: "~> 1.0",
      package: package,
      description: description,
@@ -51,9 +51,9 @@ defmodule PhoenixTokenAuth.Mixfile do
   defp deps do
     [
         {:cowboy, "~> 1.0.0"},
-        {:phoenix, ">= 0.7.0"},
-        {:ecto, "~> 0.10.0"},
-        {:comeonin, "~> 0.2.4"},
+        {:phoenix, ">= 0.12.0"},
+        {:ecto, "~> 0.11.0"},
+        {:comeonin, "~> 0.7"},
         {:postgrex, ">= 0.6.0"},
         {:timex, "~> 0.13.0"},
         {:joken, "~> 0.8.1"},

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PhoenixTokenAuth.Mixfile do
 
   def project do
     [app: :phoenix_token_auth,
-     version: "0.0.7-kal",
+     version: "0.0.7",
      elixir: "~> 1.0",
      package: package,
      description: description,

--- a/test/confirmator_test.exs
+++ b/test/confirmator_test.exs
@@ -16,7 +16,7 @@ defmodule ConfirmatorTest do
     {_token, user} = Forge.user(hashed_confirmation_token: "123secret")
     |> Ecto.Changeset.cast(nil, [])
     |> Confirmator.confirmation_needed_changeset
-    user = Ecto.Changeset.apply(user)
+    user = Ecto.Changeset.apply_changes(user)
 
     changeset = Confirmator.confirmation_changeset(user, %{"confirmation_token" => "wrong"})
 
@@ -30,7 +30,7 @@ defmodule ConfirmatorTest do
       {token, user} = Forge.user(hashed_confirmation_token: "123secret")
       |> Ecto.Changeset.cast(nil, [])
       |> Confirmator.confirmation_needed_changeset
-      user = Ecto.Changeset.apply(user)
+      user = Ecto.Changeset.apply_changes(user)
 
       changeset = Confirmator.confirmation_changeset(user, %{"confirmation_token" => token})
 

--- a/test/confirmator_test.exs
+++ b/test/confirmator_test.exs
@@ -6,7 +6,9 @@ defmodule ConfirmatorTest do
 
 
   test "confirmation_needed_changeset adds the hashed token" do
-    {token, changeset} = Confirmator.confirmation_needed_changeset(%Ecto.Changeset{})
+    {token, changeset} = %Ecto.Changeset{} 
+      |> Ecto.Changeset.cast(:empty, [], [])
+      |> Confirmator.confirmation_needed_changeset()
     hashed_confirmation_token = Ecto.Changeset.get_change(changeset, :hashed_confirmation_token)
 
     assert crypto_provider.checkpw(token, hashed_confirmation_token)


### PR DESCRIPTION
To use phoenix_token_auth with a recent version of phoenix, ecto and comonein some modifications in the tests have to be done. They are required due to breaking changes in ecto. There is still a deprecation warning from phoenix for setting headers in a connection, but currently it works. 

All tests are green again.
