### PR TITLE
Configuration without anonymous functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,10 @@ config :phoenix_token_auth,
   crypto_provider: Comeonin.Bcrypt,                                                    # crypto provider for hashing passwords/tokens. see http://hexdocs.pm/comeonin/
   token_validity_in_minutes: 7 * 24 * 60                                               # minutes from login until a token expires
   email_sender: "myapp@example.com",                                                   # sender address of emails sent by the app
-  welcome_email_subject: fn user -> "Hello #{user.email}" end,                         # function returning the subject of a welcome email
-  welcome_email_body: fn user, confirmation_token -> confirmation_token end,           # function returning the body of a welcome email
-  password_reset_email_subject: fn user -> "Hello #{user.email}" end,                  # function returning the subject of a welcome email
-  password_reset_email_body: fn user, reset_token -> reset_token end,                  # function returning the body of a welcome email
-  new_email_address_email_subject: fn user -> "Hello #{user.email}" end,               # function returning the subject of the email sent when the users changes his email address
-  new_email_address_email_body: fn user, confirmation_token -> confirmation_token end, # function returning the body of the email sent when the users changes his email address
+  emailing_module: MyApp.EmailConstructor                                              # module implementing the `PhoenixTokenAuth.MailingBehaviour` for generating emails
   mailgun_domain: "example.com"                                                        # domain of your mailgun account
   mailgun_key: "secret",                                                               # secret key of your mailgun account
-  user_model_validator: fn changeset -> changeset end                                  # function receiving and returning the changeset for a user on registration and when updating the account. This is the place to run custom validations.
+  user_model_validator: {MyApp.Model, :user_validator}                                 # function receiving and returning the changeset for a user on registration and when updating the account. This is the place to run custom validations.
 ```
 
 The secret key for signing tokens must be provided for Joken to work. You must

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,12 +2,7 @@ use Mix.Config
 
 config :phoenix_token_auth,
   email_sender: "myapp@example.com",
-  welcome_email_subject: fn user -> "Hello #{user.email}" end,
-  welcome_email_body: fn user, token -> "the_emails_body" end,
-  password_reset_email_subject: fn user -> "Hello #{user.email}" end,
-  password_reset_email_body: fn user, token -> "the_emails_body" end,
-  new_email_address_email_subject: fn user -> "Please confirm your email address" end,
-  new_email_address_email_body: fn user, token -> token end,
+  emailing_module: PhoenixTokenAuth.TestMailing,
   user_model: PhoenixTokenAuth.User,
   repo: PhoenixTokenAuth.TestRepo
 

--- a/lib/phoenix_token_auth/helpers/mailing_behaviour.ex
+++ b/lib/phoenix_token_auth/helpers/mailing_behaviour.ex
@@ -1,0 +1,41 @@
+defmodule PhoenixTokenAuth.MailingBehaviour do
+	use Behaviour
+
+	@doc """
+	Function returning the subject of a welcome email for the given
+	user. 
+	"""
+	defcallback  welcome_subject(any) ::  String.t
+
+	@doc """
+	Function returning the body of a welcome email. Parameter is 
+	the User struct and the confirmation token. 
+	"""
+	defcallback welcome_body(any, String.t) :: String.t
+
+	@doc """
+	Function returning the subject of a password reset email for the given
+	user. 
+	"""
+	defcallback password_reset_subject(any) :: String.t 
+
+	@doc """
+	Function returning the body of a password reset email. Parameter is 
+	the User struct and the reset token. 
+	"""
+	defcallback password_reset_body(any, String.t) :: String.t
+
+	@doc """
+	Function returning the subject of a new email-address email for the given
+	user. 
+	"""
+	defcallback new_email_address_subject(any) :: String.t 
+
+	@doc """
+	Function returning the body of a new email-address email. Parameter is 
+	the User struct and the reset token. 
+	"""
+	defcallback new_email_address_body(any, String.t) :: String.t
+
+
+end

--- a/lib/phoenix_token_auth/helpers/user_helper.ex
+++ b/lib/phoenix_token_auth/helpers/user_helper.ex
@@ -16,6 +16,7 @@ defmodule PhoenixTokenAuth.UserHelper do
                                  changeset)
   end
   defp apply_validator(nil, changeset), do: changeset
+  defp apply_validator({mod, fun}, changeset), do: apply(mod, fun, [changeset])
   defp apply_validator(validator, changeset) do
     validator.(changeset)
   end

--- a/lib/phoenix_token_auth/mailer.ex
+++ b/lib/phoenix_token_auth/mailer.ex
@@ -9,6 +9,7 @@ defmodule PhoenixTokenAuth.Mailer do
         email_sender: "myapp@example.com",
         mailgun_domain: "example.com",
         mailgun_key: "secret"
+        emailing_module: PhoenixTokenAuth.TestMailing
   """
 
   use Mailgun.Client, domain: Application.get_env(:phoenix_token_auth, :mailgun_domain),
@@ -25,8 +26,9 @@ defmodule PhoenixTokenAuth.Mailer do
   welcome_email_body the user and confirmation token.
   """
   def send_welcome_email(user, confirmation_token) do
-    subject = Application.get_env(:phoenix_token_auth, :welcome_email_subject).(user)
-    body = Application.get_env(:phoenix_token_auth, :welcome_email_body).(user, confirmation_token)
+    email_mod = Application.get_env(:phoenix_token_auth, :emailing_module)
+    subject = email_mod.welcome_subject(user)
+    body = email_mod.welcome_body(user, confirmation_token)
     from = Application.get_env(:phoenix_token_auth, :email_sender)
 
     {:ok, _} = send_email(to: user.email,
@@ -45,8 +47,9 @@ defmodule PhoenixTokenAuth.Mailer do
   password_reset_email_body the user and reset token.
   """
   def send_password_reset_email(user, reset_token) do
-    subject = Application.get_env(:phoenix_token_auth, :password_reset_email_subject).(user)
-    body = Application.get_env(:phoenix_token_auth, :password_reset_email_body).(user, reset_token)
+    email_mod = Application.get_env(:phoenix_token_auth, :emailing_module)
+    subject = email_mod.password_reset_subject(user)
+    body = email_mod.password_reset_body(user, reset_token)
     from = Application.get_env(:phoenix_token_auth, :email_sender)
 
     {:ok, _} = send_email(to: user.email,
@@ -65,8 +68,9 @@ defmodule PhoenixTokenAuth.Mailer do
   new_email_address_email_body the user and confirmation token.
   """
   def send_new_email_address_email(user, confirmation_token) do
-    subject = Application.get_env(:phoenix_token_auth, :new_email_address_email_subject).(user)
-    body = Application.get_env(:phoenix_token_auth, :new_email_address_email_body).(user, confirmation_token)
+    email_mod = Application.get_env(:phoenix_token_auth, :emailing_module)
+    subject = email_mod.new_email_address_subject(user)
+    body = email_mod.new_email_address_body(user, confirmation_token)
     from = Application.get_env(:phoenix_token_auth, :email_sender)
 
     {:ok, _} = send_email(to: user.unconfirmed_email,

--- a/test/support/mailing_helper.exs
+++ b/test/support/mailing_helper.exs
@@ -2,10 +2,10 @@ defmodule PhoenixTokenAuth.TestMailing do
 	@behaviour PhoenixTokenAuth.MailingBehaviour
 
 	def welcome_subject(user), do: "Hello #{user.email}"
-	def welcome_body(_user, token), do: token		
+	def welcome_body(_user, _token), do: "the_emails_body" 		
 	def password_reset_subject(user), do: "Hello #{user.email}"
-	def password_reset_body(_user, token), do: token		
-	def new_email_address_subject(user), do: "Hello #{user.email}"
-	def new_email_address_body(_user, token), do: token		
+	def password_reset_body(_user, _token), do: "the_emails_body" 		
+	def new_email_address_subject(_user), do: "Please confirm your email address"
+	def new_email_address_body(_user, token), do: token
 	
 end

--- a/test/support/mailing_helper.exs
+++ b/test/support/mailing_helper.exs
@@ -1,0 +1,11 @@
+defmodule PhoenixTokenAuth.TestMailing do
+	@behaviour PhoenixTokenAuth.MailingBehaviour
+
+	def welcome_subject(user), do: "Hello #{user.email}"
+	def welcome_body(user, token), do: token		
+	def password_reset_subject(user), do: "Hello #{user.email}"
+	def password_reset_body(user, token), do: token		
+	def new_email_address_subject(user), do: "Hello #{user.email}"
+	def new_email_address_body(user, token), do: token		
+	
+end

--- a/test/support/mailing_helper.exs
+++ b/test/support/mailing_helper.exs
@@ -2,10 +2,10 @@ defmodule PhoenixTokenAuth.TestMailing do
 	@behaviour PhoenixTokenAuth.MailingBehaviour
 
 	def welcome_subject(user), do: "Hello #{user.email}"
-	def welcome_body(user, token), do: token		
+	def welcome_body(_user, token), do: token		
 	def password_reset_subject(user), do: "Hello #{user.email}"
-	def password_reset_body(user, token), do: token		
+	def password_reset_body(_user, token), do: token		
 	def new_email_address_subject(user), do: "Hello #{user.email}"
-	def new_email_address_body(user, token), do: token		
+	def new_email_address_body(_user, token), do: token		
 	
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,3 +6,4 @@ Application.put_env(:phoenix, :format_encoders, [json: Poison])
 Code.require_file "test/support/ecto_helper.exs"
 Code.require_file "test/support/router_helper.exs"
 Code.require_file "test/support/forge.exs"
+Code.require_file "test/support/mailing_helper.exs"


### PR DESCRIPTION
Anonymous functions in the config file are elegant, but they do not work properly with `exrm`, which generates an Erlang-based sys.config file which cannot use the Elixir syntax. IMHO this configuration style is well suited for prototyping but not for production systems. 

For an easy configuration a behaviour `PhoenixTokenAuth.MailingBehaviour` is defined for constructing the three different emails. It is sufficient to configure the name of the implementing module. 

For the user model changeset validator a module and function can be configured instead of an anonymous function.
