### PR TITLE
Add password strategy compatible with simple-ember-auth : refactor branch

### DIFF
--- a/lib/phoenix_token_auth/authenticator.ex
+++ b/lib/phoenix_token_auth/authenticator.ex
@@ -11,8 +11,16 @@ Returns:
 * {:error, message} if the user was not confirmed before or no matching user was found
 """
   @unconfirmed_account_error_message "Account not confirmed yet. Please follow the instructions we sent you by email."
-  def authenticate(email, password) do
+  def authenticate_email(email, password) do
     user = UserHelper.find_by_email(email)
+    authenticate(user, password)
+  end
+  def authenticate_username(username, password) do
+    user = UserHelper.find_by_username(username)
+    authenticate(user, password)
+  end
+
+  def authenticate(user, password) do
     case check_password(user, password) do
       {:ok, %{confirmed_at: nil}} -> {:error, %{base: @unconfirmed_account_error_message}}
       {:ok, _} -> {:ok, user}

--- a/lib/phoenix_token_auth/authenticator.ex
+++ b/lib/phoenix_token_auth/authenticator.ex
@@ -11,11 +11,11 @@ Returns:
 * {:error, message} if the user was not confirmed before or no matching user was found
 """
   @unconfirmed_account_error_message "Account not confirmed yet. Please follow the instructions we sent you by email."
-  def authenticate_email(email, password) do
+  def authenticate_by_email(email, password) do
     user = UserHelper.find_by_email(email)
     authenticate(user, password)
   end
-  def authenticate_username(username, password) do
+  def authenticate_by_username(username, password) do
     user = UserHelper.find_by_username(username)
     authenticate(user, password)
   end

--- a/lib/phoenix_token_auth/controllers/account_controller.ex
+++ b/lib/phoenix_token_auth/controllers/account_controller.ex
@@ -33,7 +33,7 @@ defmodule PhoenixTokenAuth.Controllers.Account do
     |> AccountUpdater.changeset(params)
     if changeset.valid? do
       case Util.repo.transaction fn ->
-        user = Util.repo.update(changeset)
+        user = Util.repo.update!(changeset)
         if (confirmation_token != nil) do
           Mailer.send_new_email_address_email(user, confirmation_token)
         end

--- a/lib/phoenix_token_auth/controllers/password_resets_controller.ex
+++ b/lib/phoenix_token_auth/controllers/password_resets_controller.ex
@@ -26,7 +26,7 @@ defmodule PhoenixTokenAuth.Controllers.PasswordResets do
 
     if changeset.valid? do
       case Util.repo.transaction fn ->
-        user = Util.repo.update(changeset)
+        user = Util.repo.update!(changeset)
         Mailer.send_password_reset_email(user, password_reset_token)
       end do
         {:ok, _} -> json conn, :ok
@@ -50,7 +50,7 @@ defmodule PhoenixTokenAuth.Controllers.PasswordResets do
     changeset = PasswordResetter.reset_changeset(user, params)
 
     if changeset.valid? do
-      user = Util.repo.update(changeset)
+      user = Util.repo.update!(changeset)
       token = Authenticator.generate_token_for(user)
       json conn, %{token: token}
     else

--- a/lib/phoenix_token_auth/controllers/sessions_controller.ex
+++ b/lib/phoenix_token_auth/controllers/sessions_controller.ex
@@ -17,7 +17,7 @@ defmodule PhoenixTokenAuth.Controllers.Sessions do
   """
   def create(conn, %{"username" => username, "password" => password}) do
     case Authenticator.authenticate_by_username(username, password) do
-      {:ok, user} -> json conn, %{access_token: Authenticator.generate_token_for(user), token_type: "bearer"}
+      {:ok, user} -> json conn, %{access_token: Authenticator.generate_token_for(user), token_type: "bearer", id: user.id}
       {:error, errors} -> Util.send_error(conn, errors, 401)
     end
   end

--- a/lib/phoenix_token_auth/controllers/sessions_controller.ex
+++ b/lib/phoenix_token_auth/controllers/sessions_controller.ex
@@ -15,15 +15,15 @@ defmodule PhoenixTokenAuth.Controllers.Sessions do
   Responds with status 200 and {token: token} if credentials were correct.
   Responds with status 401 and {errors: error_message} otherwise.
   """
-  def create(conn, %{"email" => email, "password" => password, "grant_type" => "password"}) do
-    case Authenticator.authenticate(email, password) do
+  def create(conn, %{"username" => username, "password" => password, "grant_type" => "password"}) do
+    case Authenticator.authenticate_username(username, password) do
       {:ok, user} -> json conn, %{access_token: Authenticator.generate_token_for(user), token_type: "bearer"}
       {:error, errors} -> Util.send_error(conn, errors, 401)
     end
   end
 
   def create(conn, %{"email" => email, "password" => password}) do
-    case Authenticator.authenticate(email, password) do
+    case Authenticator.authenticate_email(email, password) do
       {:ok, user} -> json conn, %{token: Authenticator.generate_token_for(user)}
       {:error, errors} -> Util.send_error(conn, errors, 401)
     end

--- a/lib/phoenix_token_auth/controllers/sessions_controller.ex
+++ b/lib/phoenix_token_auth/controllers/sessions_controller.ex
@@ -15,7 +15,7 @@ defmodule PhoenixTokenAuth.Controllers.Sessions do
   Responds with status 200 and {token: token} if credentials were correct.
   Responds with status 401 and {errors: error_message} otherwise.
   """
-  def create(conn, %{"username" => username, "password" => password, "grant_type" => "password"}) do
+  def create(conn, %{"username" => username, "password" => password}) do
     case Authenticator.authenticate_by_username(username, password) do
       {:ok, user} -> json conn, %{access_token: Authenticator.generate_token_for(user), token_type: "bearer"}
       {:error, errors} -> Util.send_error(conn, errors, 401)

--- a/lib/phoenix_token_auth/controllers/sessions_controller.ex
+++ b/lib/phoenix_token_auth/controllers/sessions_controller.ex
@@ -15,6 +15,13 @@ defmodule PhoenixTokenAuth.Controllers.Sessions do
   Responds with status 200 and {token: token} if credentials were correct.
   Responds with status 401 and {errors: error_message} otherwise.
   """
+  def create(conn, %{"email" => email, "password" => password, "grant_type" => "password"}) do
+    case Authenticator.authenticate(email, password) do
+      {:ok, user} -> json conn, %{access_token: Authenticator.generate_token_for(user), token_type: "bearer"}
+      {:error, errors} -> Util.send_error(conn, errors, 401)
+    end
+  end
+
   def create(conn, %{"email" => email, "password" => password}) do
     case Authenticator.authenticate(email, password) do
       {:ok, user} -> json conn, %{token: Authenticator.generate_token_for(user)}

--- a/lib/phoenix_token_auth/controllers/sessions_controller.ex
+++ b/lib/phoenix_token_auth/controllers/sessions_controller.ex
@@ -16,14 +16,14 @@ defmodule PhoenixTokenAuth.Controllers.Sessions do
   Responds with status 401 and {errors: error_message} otherwise.
   """
   def create(conn, %{"username" => username, "password" => password, "grant_type" => "password"}) do
-    case Authenticator.authenticate_username(username, password) do
+    case Authenticator.authenticate_by_username(username, password) do
       {:ok, user} -> json conn, %{access_token: Authenticator.generate_token_for(user), token_type: "bearer"}
       {:error, errors} -> Util.send_error(conn, errors, 401)
     end
   end
 
   def create(conn, %{"email" => email, "password" => password}) do
-    case Authenticator.authenticate_email(email, password) do
+    case Authenticator.authenticate_by_email(email, password) do
       {:ok, user} -> json conn, %{token: Authenticator.generate_token_for(user)}
       {:error, errors} -> Util.send_error(conn, errors, 401)
     end

--- a/lib/phoenix_token_auth/controllers/users_controller.ex
+++ b/lib/phoenix_token_auth/controllers/users_controller.ex
@@ -32,9 +32,7 @@ defmodule PhoenixTokenAuth.Controllers.Users do
     if changeset.valid? do
       case Util.repo.transaction fn ->
         user = Util.repo.insert(changeset)
-        unless params["username"] do
-          Mailer.send_welcome_email(user, confirmation_token)
-        end
+        Mailer.send_welcome_email(user, confirmation_token)
       end do
         {:ok, _} -> json conn, :ok
       end

--- a/lib/phoenix_token_auth/controllers/users_controller.ex
+++ b/lib/phoenix_token_auth/controllers/users_controller.ex
@@ -29,10 +29,13 @@ defmodule PhoenixTokenAuth.Controllers.Users do
       |> Confirmator.confirmation_needed_changeset
     end
 
+
     if changeset.valid? do
       case Util.repo.transaction fn ->
         user = Util.repo.insert(changeset)
-        Mailer.send_welcome_email(user, confirmation_token)
+        if user.email do
+           Mailer.send_welcome_email(user, confirmation_token)
+        end
       end do
         {:ok, _} -> json conn, :ok
       end

--- a/lib/phoenix_token_auth/helpers/user_helper.ex
+++ b/lib/phoenix_token_auth/helpers/user_helper.ex
@@ -14,7 +14,7 @@ defmodule PhoenixTokenAuth.UserHelper do
     query = from u in model, where: u.username == ^username
     Util.repo.one query
   end
-  
+
   def validator(changeset) do
     apply_validator(Application.get_env(:phoenix_token_auth, :user_model_validator),
                                  changeset)
@@ -30,7 +30,7 @@ defmodule PhoenixTokenAuth.UserHelper do
     alias Ecto.Changeset
     Changeset.cast(user, %{}, [])
     |> Changeset.put_change(:authentication_tokens, [token | user.authentication_tokens])
-    |> Util.repo.update
+    |> Util.repo.update!
     token
   end
 end

--- a/lib/phoenix_token_auth/helpers/user_helper.ex
+++ b/lib/phoenix_token_auth/helpers/user_helper.ex
@@ -10,7 +10,11 @@ defmodule PhoenixTokenAuth.UserHelper do
     query = from u in model, where: u.email == ^email
     Util.repo.one query
   end
-
+  def find_by_username(username) do
+    query = from u in model, where: u.username == ^username
+    Util.repo.one query
+  end
+  
   def validator(changeset) do
     apply_validator(Application.get_env(:phoenix_token_auth, :user_model_validator),
                                  changeset)

--- a/lib/phoenix_token_auth/mailer.ex
+++ b/lib/phoenix_token_auth/mailer.ex
@@ -25,7 +25,6 @@ defmodule PhoenixTokenAuth.Mailer do
   Both config fields have to be functions returning binaries. welcome_email_subject receives the user and
   welcome_email_body the user and confirmation token.
   """
-  def send_welcome_email(%{email: email}, _) when email == nil do end
   def send_welcome_email(user, confirmation_token) do
     subject = email_mod.welcome_subject(user)
     body = email_mod.welcome_body(user, confirmation_token)

--- a/lib/phoenix_token_auth/mailer.ex
+++ b/lib/phoenix_token_auth/mailer.ex
@@ -25,6 +25,7 @@ defmodule PhoenixTokenAuth.Mailer do
   Both config fields have to be functions returning binaries. welcome_email_subject receives the user and
   welcome_email_body the user and confirmation token.
   """
+  def send_welcome_email(user = %{email: email}, confirmation_token) when email == nil do end
   def send_welcome_email(user, confirmation_token) do
     subject = email_mod.welcome_subject(user)
     body = email_mod.welcome_body(user, confirmation_token)

--- a/lib/phoenix_token_auth/mailer.ex
+++ b/lib/phoenix_token_auth/mailer.ex
@@ -25,7 +25,7 @@ defmodule PhoenixTokenAuth.Mailer do
   Both config fields have to be functions returning binaries. welcome_email_subject receives the user and
   welcome_email_body the user and confirmation token.
   """
-  def send_welcome_email(user = %{email: email}, confirmation_token) when email == nil do end
+  def send_welcome_email(%{email: email}, _) when email == nil do end
   def send_welcome_email(user, confirmation_token) do
     subject = email_mod.welcome_subject(user)
     body = email_mod.welcome_body(user, confirmation_token)

--- a/lib/phoenix_token_auth/registrator.ex
+++ b/lib/phoenix_token_auth/registrator.ex
@@ -7,23 +7,26 @@ defmodule PhoenixTokenAuth.Registrator do
   Returns a changeset setting email and hashed_password on a new user.
   Validates that email and password are present and that email is unique.
   """
-  def changeset(params) do
+  def changeset(params = %{"username" => username}) when username != "" and username != nil do
+    Changeset.cast(struct(UserHelper.model), params, ~w(username))
+    |> Changeset.validate_change(:username, &Util.presence_validator/2)
+    |> Changeset.validate_unique(:username, on: Util.repo)
+    |> Changeset.put_change(:hashed_confirmation_token, nil)
+    |> Changeset.put_change(:confirmed_at, Ecto.DateTime.utc)
+    |> changeset_helper
+  end
 
-    if params["username"] do
-      Changeset.cast(struct(UserHelper.model), params, ~w(username))
-      |> Changeset.validate_change(:username, &Util.presence_validator/2)
-      |> Changeset.validate_unique(:username, on: Util.repo)
-      |> UserHelper.validator
-      |> set_hashed_password
-      |> Changeset.put_change(:hashed_confirmation_token, nil)
-      |> Changeset.put_change(:confirmed_at, Ecto.DateTime.utc)
-    else
-      Changeset.cast(struct(UserHelper.model), params, ~w(email))
-      |> Changeset.validate_change(:email, &Util.presence_validator/2)
-      |> Changeset.validate_unique(:email, on: Util.repo)
-      |> UserHelper.validator
-      |> set_hashed_password
-    end
+  def changeset(params) do
+    Changeset.cast(struct(UserHelper.model), params, ~w(email))
+    |> Changeset.validate_change(:email, &Util.presence_validator/2)
+    |> Changeset.validate_unique(:email, on: Util.repo)
+    |> changeset_helper
+  end
+
+  def changeset_helper(changeset) do
+    changeset
+    |> UserHelper.validator
+    |> set_hashed_password
   end
 
   def set_hashed_password(changeset = %{errors: [_]}), do: changeset

--- a/lib/phoenix_token_auth/registrator.ex
+++ b/lib/phoenix_token_auth/registrator.ex
@@ -8,13 +8,23 @@ defmodule PhoenixTokenAuth.Registrator do
   Validates that email and password are present and that email is unique.
   """
   def changeset(params) do
-    Changeset.cast(struct(UserHelper.model), params, ~w(email))
-    |> Changeset.validate_change(:email, &Util.presence_validator/2)
-    |> Changeset.validate_unique(:email, on: Util.repo)
-    |> UserHelper.validator
-    |> set_hashed_password
-  end
 
+    if params["username"] do
+      Changeset.cast(struct(UserHelper.model), params, ~w(username))
+      |> Changeset.validate_change(:username, &Util.presence_validator/2)
+      |> Changeset.validate_unique(:username, on: Util.repo)
+      |> UserHelper.validator
+      |> set_hashed_password
+      |> Changeset.put_change(:hashed_confirmation_token, nil)
+      |> Changeset.put_change(:confirmed_at, Ecto.DateTime.utc)
+    else
+      Changeset.cast(struct(UserHelper.model), params, ~w(email))
+      |> Changeset.validate_change(:email, &Util.presence_validator/2)
+      |> Changeset.validate_unique(:email, on: Util.repo)
+      |> UserHelper.validator
+      |> set_hashed_password
+    end
+  end
 
   def set_hashed_password(changeset = %{errors: [_]}), do: changeset
   def set_hashed_password(changeset = %{params: %{"password" => password}}) when password != "" and password != nil do

--- a/lib/phoenix_token_auth/registrator.ex
+++ b/lib/phoenix_token_auth/registrator.ex
@@ -16,15 +16,11 @@ defmodule PhoenixTokenAuth.Registrator do
     |> changeset_helper
   end
 
-  def changeset(params = %{"email" => email}) when email != "" and email != nil do
+  def changeset(params) do
     Changeset.cast(struct(UserHelper.model), params, ~w(email))
     |> Changeset.validate_change(:email, &Util.presence_validator/2)
     |> Changeset.validate_unique(:email, on: Util.repo)
     |> changeset_helper
-  end
-
-  def changeset(params) do
-    Changeset.cast(struct(UserHelper.model), params, ~w())
   end
 
   defp changeset_helper(changeset) do

--- a/lib/phoenix_token_auth/registrator.ex
+++ b/lib/phoenix_token_auth/registrator.ex
@@ -16,11 +16,15 @@ defmodule PhoenixTokenAuth.Registrator do
     |> changeset_helper
   end
 
-  def changeset(params) do
+  def changeset(params = %{"email" => email}) when email != "" and email != nil do
     Changeset.cast(struct(UserHelper.model), params, ~w(email))
     |> Changeset.validate_change(:email, &Util.presence_validator/2)
     |> Changeset.validate_unique(:email, on: Util.repo)
     |> changeset_helper
+  end
+
+  def changeset(params) do
+    Changeset.cast(struct(UserHelper.model), params, ~w())
   end
 
   defp changeset_helper(changeset) do

--- a/lib/phoenix_token_auth/registrator.ex
+++ b/lib/phoenix_token_auth/registrator.ex
@@ -23,7 +23,7 @@ defmodule PhoenixTokenAuth.Registrator do
     |> changeset_helper
   end
 
-  def changeset_helper(changeset) do
+  defp changeset_helper(changeset) do
     changeset
     |> UserHelper.validator
     |> set_hashed_password

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule PhoenixTokenAuth.Mixfile do
         {:phoenix, ">= 0.12.0"},
         {:phoenix, ">= 0.12.0"},
         {:phoenix_html, ">= 1.0.0"},
-        {:ecto, "~> 0.11.0"},
+        {:ecto, "~> 0.12.0"},
         {:comeonin, "~> 0.10.0"},
         {:postgrex, ">= 0.6.0"},
         {:joken, "~> 0.13.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,7 @@
   "cowlib": {:hex, :cowlib, "1.0.1"},
   "decimal": {:hex, :decimal, "1.1.0"},
   "earmark": {:hex, :earmark, "0.1.17"},
-  "ecto": {:hex, :ecto, "0.11.3"},
+  "ecto": {:hex, :ecto, "0.12.1"},
   "ex_doc": {:hex, :ex_doc, "0.7.3"},
   "faker": {:hex, :faker, "0.5.1"},
   "joken": {:hex, :joken, "0.13.1"},
@@ -16,7 +16,7 @@
   "plug": {:hex, :plug, "0.12.2"},
   "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
-  "postgrex": {:hex, :postgrex, "0.8.1"},
+  "postgrex": {:hex, :postgrex, "0.8.4"},
   "ranch": {:hex, :ranch, "1.0.0"},
   "secure_random": {:hex, :secure_random, "0.1.1"},
   "timex": {:hex, :timex, "0.13.4"}}

--- a/test/authenticator_test.exs
+++ b/test/authenticator_test.exs
@@ -11,16 +11,16 @@ defmodule AuthenticatorTest do
 
   test "authenticate a confirmed user" do
     user = Forge.saved_confirmed_user TestRepo
-    {:ok, _} = Authenticator.authenticate(user.email, "secret")
+    {:ok, _} = Authenticator.authenticate_email(user.email, "secret")
   end
 
   test "authenticate an unconfirmed user" do
     user = Forge.saved_user TestRepo
-    assert Authenticator.authenticate(user.email, "secret") == {:error, %{base: "Account not confirmed yet. Please follow the instructions we sent you by email."}}
+    assert Authenticator.authenticate_email(user.email, "secret") == {:error, %{base: "Account not confirmed yet. Please follow the instructions we sent you by email."}}
   end
 
   test "authenticate an unknown user" do
-    assert Authenticator.authenticate("user@example.com", "secret") == {:error, %{base: "Unknown email or password"}}
+    assert Authenticator.authenticate_email("user@example.com", "secret") == {:error, %{base: "Unknown email or password"}}
   end
 
 

--- a/test/authenticator_test.exs
+++ b/test/authenticator_test.exs
@@ -11,16 +11,16 @@ defmodule AuthenticatorTest do
 
   test "authenticate a confirmed user" do
     user = Forge.saved_confirmed_user TestRepo
-    {:ok, _} = Authenticator.authenticate_email(user.email, "secret")
+    {:ok, _} = Authenticator.authenticate_by_email(user.email, "secret")
   end
 
   test "authenticate an unconfirmed user" do
     user = Forge.saved_user TestRepo
-    assert Authenticator.authenticate_email(user.email, "secret") == {:error, %{base: "Account not confirmed yet. Please follow the instructions we sent you by email."}}
+    assert Authenticator.authenticate_by_email(user.email, "secret") == {:error, %{base: "Account not confirmed yet. Please follow the instructions we sent you by email."}}
   end
 
   test "authenticate an unknown user" do
-    assert Authenticator.authenticate_email("user@example.com", "secret") == {:error, %{base: "Unknown email or password"}}
+    assert Authenticator.authenticate_by_email("user@example.com", "secret") == {:error, %{base: "Unknown email or password"}}
   end
 
 

--- a/test/confirmation_test.exs
+++ b/test/confirmation_test.exs
@@ -21,7 +21,7 @@ defmodule ConfirmationTest do
   test "confirm user with wrong token" do
     {_, changeset} = Registrator.changeset(%{email: @email, password: @password})
     |> Confirmator.confirmation_needed_changeset
-    user = repo.insert changeset
+    user = repo.insert! changeset
 
     conn = call(TestRouter, :post, "/api/users/#{user.id}/confirm", %{confirmation_token: "wrong_token"}, @headers)
     assert conn.status == 422
@@ -31,7 +31,7 @@ defmodule ConfirmationTest do
   test "confirm a user" do
     {token, changeset} = Registrator.changeset(%{email: @email, password: @password})
     |> Confirmator.confirmation_needed_changeset
-    user = repo.insert changeset
+    user = repo.insert! changeset
 
     conn = call(TestRouter, :post, "/api/users/#{user.id}/confirm", %{confirmation_token: token}, @headers)
     assert conn.status == 200
@@ -50,13 +50,13 @@ defmodule ConfirmationTest do
   test "confirm a user's new email" do
     {token, changeset} = Registrator.changeset(%{email: @email, password: @password})
     |> Confirmator.confirmation_needed_changeset
-    user = repo.insert changeset
+    user = repo.insert! changeset
     Confirmator.confirmation_changeset(user, %{"confirmation_token" => token})
-    |> TestRepo.update
+    |> TestRepo.update!
 
     user = TestRepo.one(User)
     {token, changeset} = AccountUpdater.changeset(user, %{"email" => "new@example.com"})
-    user = TestRepo.update(changeset)
+    user = TestRepo.update!(changeset)
 
     conn = call(TestRouter, :post, "/api/users/#{user.id}/confirm", %{confirmation_token: token}, @headers)
     assert conn.status == 200

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -10,6 +10,7 @@ defmodule LoginTest do
 
 
   @email "user@example.com"
+  @username "user@example.com"
   @password "secret"
   @headers [{"Content-Type", "application/json"}]
 
@@ -50,4 +51,29 @@ defmodule LoginTest do
     assert repo.one(UserHelper.model).authentication_tokens == [token]
   end
 
+  test "sign in with unknown username" do
+    conn = call(TestRouter, :post, "/api/sessions", %{password: @password, username: @username}, @headers)
+    assert conn.status == 401
+    assert conn.resp_body == Poison.encode!(%{errors: %{base: "Unknown email or password"}})
+  end
+
+  # test "sign in with username and wrong password" do
+  #   Registrator.changeset(%{:username => @username, :password => @password})
+  #   |> repo.insert
+  #
+  #   conn = call(TestRouter, :post, "/api/sessions", %{password: "wrong", username: @username}, @headers)
+  #   assert conn.status == 401
+  #   assert conn.resp_body == Poison.encode!(%{errors: %{base: "Unknown email or password"}})
+  # end
+  #
+  # test "sign in user with username" do
+  #   Registrator.changeset(%{:username => @username, :password => @password})
+  #   |> repo.insert
+  #
+  #   conn = call(TestRouter, :post, "/api/sessions", %{password: @password, username: @username}, @headers)
+  #   assert conn.status == 200
+  #   %{"access_token" => token, "token_type" => "bearer"} = Poison.decode!(conn.resp_body)
+  #
+  #   assert repo.one(UserHelper.model).authentication_tokens == [token]
+  # end
 end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -22,7 +22,7 @@ defmodule LoginTest do
 
   test "sign in with wrong password" do
     Registrator.changeset(%{email: @email, password: @password})
-    |> repo.insert
+    |> repo.insert!
 
     conn = call(TestRouter, :post, "/api/sessions", %{password: "wrong", email: @email}, @headers)
     assert conn.status == 401
@@ -30,9 +30,9 @@ defmodule LoginTest do
   end
 
   test "sign in as unconfirmed user" do
-    {_, changeset} = Registrator.changeset(%{email: @email, password: @password})
+    {_, changeset} = Registrator.changeset(%{"email" => @email, "password" => @password})
     |> Confirmator.confirmation_needed_changeset
-    repo.insert changeset
+    repo.insert! changeset
 
     conn = call(TestRouter, :post, "/api/sessions", %{password: @password, email: @email}, @headers)
     assert conn.status == 401
@@ -40,9 +40,9 @@ defmodule LoginTest do
   end
 
   test "sign in as confirmed user" do
-    Registrator.changeset(%{email: @email, password: @password})
+    Registrator.changeset(%{"email" => @email, "password" => @password})
     |> Ecto.Changeset.put_change(:confirmed_at, Ecto.DateTime.utc)
-    |> repo.insert
+    |> repo.insert!
 
     conn = call(TestRouter, :post, "/api/sessions", %{password: @password, email: @email}, @headers)
     assert conn.status == 200
@@ -59,7 +59,7 @@ defmodule LoginTest do
 
   test "sign in with username and wrong password" do
     Registrator.changeset(%{"username" => @username, "password" => @password})
-    |> repo.insert
+    |> repo.insert!
 
     conn = call(TestRouter, :post, "/api/sessions", %{password: "wrong", username: @username}, @headers)
     assert conn.status == 401
@@ -68,7 +68,7 @@ defmodule LoginTest do
 
   test "sign in user with username" do
     Registrator.changeset(%{"username" => @username, "password" => @password})
-    |> repo.insert
+    |> repo.insert!
 
     conn = call(TestRouter, :post, "/api/sessions", %{password: @password, username: @username}, @headers)
     assert conn.status == 200

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -76,4 +76,17 @@ defmodule LoginTest do
 
     assert repo.one(UserHelper.model).authentication_tokens == [token]
   end
+
+test "sign in user with username and test sending email" do
+  changeset = Registrator.changeset(%{"username" => @username, "password" => @password})
+  user = repo.insert changeset
+  PhoenixTokenAuth.Mailer.send_welcome_email(user, nil)
+
+  conn = call(TestRouter, :post, "/api/sessions", %{password: @password, username: @username}, @headers)
+  assert conn.status == 200
+  %{"access_token" => token, "token_type" => "bearer"} = Poison.decode!(conn.resp_body)
+
+  assert repo.one(UserHelper.model).authentication_tokens == [token]
+end
+
 end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -77,16 +77,4 @@ defmodule LoginTest do
     assert repo.one(UserHelper.model).authentication_tokens == [token]
   end
 
-test "sign in user with username and test sending email" do
-  changeset = Registrator.changeset(%{"username" => @username, "password" => @password})
-  user = repo.insert changeset
-  PhoenixTokenAuth.Mailer.send_welcome_email(user, nil)
-
-  conn = call(TestRouter, :post, "/api/sessions", %{password: @password, username: @username}, @headers)
-  assert conn.status == 200
-  %{"access_token" => token, "token_type" => "bearer"} = Poison.decode!(conn.resp_body)
-
-  assert repo.one(UserHelper.model).authentication_tokens == [token]
-end
-
 end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -57,23 +57,23 @@ defmodule LoginTest do
     assert conn.resp_body == Poison.encode!(%{errors: %{base: "Unknown email or password"}})
   end
 
-  # test "sign in with username and wrong password" do
-  #   Registrator.changeset(%{:username => @username, :password => @password})
-  #   |> repo.insert
-  #
-  #   conn = call(TestRouter, :post, "/api/sessions", %{password: "wrong", username: @username}, @headers)
-  #   assert conn.status == 401
-  #   assert conn.resp_body == Poison.encode!(%{errors: %{base: "Unknown email or password"}})
-  # end
-  #
-  # test "sign in user with username" do
-  #   Registrator.changeset(%{:username => @username, :password => @password})
-  #   |> repo.insert
-  #
-  #   conn = call(TestRouter, :post, "/api/sessions", %{password: @password, username: @username}, @headers)
-  #   assert conn.status == 200
-  #   %{"access_token" => token, "token_type" => "bearer"} = Poison.decode!(conn.resp_body)
-  #
-  #   assert repo.one(UserHelper.model).authentication_tokens == [token]
-  # end
+  test "sign in with username and wrong password" do
+    Registrator.changeset(%{"username" => @username, "password" => @password})
+    |> repo.insert
+
+    conn = call(TestRouter, :post, "/api/sessions", %{password: "wrong", username: @username}, @headers)
+    assert conn.status == 401
+    assert conn.resp_body == Poison.encode!(%{errors: %{base: "Unknown email or password"}})
+  end
+
+  test "sign in user with username" do
+    Registrator.changeset(%{"username" => @username, "password" => @password})
+    |> repo.insert
+
+    conn = call(TestRouter, :post, "/api/sessions", %{password: @password, username: @username}, @headers)
+    assert conn.status == 200
+    %{"access_token" => token, "token_type" => "bearer"} = Poison.decode!(conn.resp_body)
+
+    assert repo.one(UserHelper.model).authentication_tokens == [token]
+  end
 end

--- a/test/registrator_test.exs
+++ b/test/registrator_test.exs
@@ -10,6 +10,7 @@ defmodule RegistratorTest do
   end
 
   @valid_params %{"password" => "secret", "email" => "unique@example.com"}
+  @valid_username_params %{"password" => "secret", "username" => "unique@example.com"}
 
   test "changeset validates presence of email" do
     changeset = Registrator.changeset(%{})
@@ -68,6 +69,18 @@ defmodule RegistratorTest do
 
     assert !changeset.valid?
     assert changeset.errors[:email] == :custom_error
+  end
+
+  test "changeset is valid with username and password" do
+    changeset = Registrator.changeset(@valid_username_params)
+    
+    assert changeset.valid?
+  end
+  test "changeset validates uniqueness of username" do
+    user = Forge.saved_user PhoenixTokenAuth.TestRepo
+    changeset = Registrator.changeset(%{"username" => user.username})
+
+    assert changeset.errors[:username] == "has already been taken"
   end
 
 end

--- a/test/registrator_test.exs
+++ b/test/registrator_test.exs
@@ -12,16 +12,16 @@ defmodule RegistratorTest do
   @valid_params %{"password" => "secret", "email" => "unique@example.com"}
   @valid_username_params %{"password" => "secret", "username" => "unique@example.com"}
 
-  test "changeset validates presence of email" do
-    changeset = Registrator.changeset(%{})
-    assert changeset.errors[:email] == "can't be blank"
-
-    changeset = Registrator.changeset(%{"email" => ""})
-    assert changeset.errors[:email] == "can't be blank"
-
-    changeset = Registrator.changeset(%{"email" => nil})
-    assert changeset.errors[:email] == "can't be blank"
-  end
+  # test "changeset validates presence of email" do
+  #   changeset = Registrator.changeset(%{})
+  #   assert changeset.errors[:email] == "can't be blank"
+  #
+  #   changeset = Registrator.changeset(%{"email" => ""})
+  #   assert changeset.errors[:email] == "can't be blank"
+  #
+  #   changeset = Registrator.changeset(%{"email" => nil})
+  #   assert changeset.errors[:email] == "can't be blank"
+  # end
 
   test "changeset validates presence of password" do
     changeset = Registrator.changeset(%{"email" => "user@example.com"})
@@ -73,7 +73,7 @@ defmodule RegistratorTest do
 
   test "changeset is valid with username and password" do
     changeset = Registrator.changeset(@valid_username_params)
-    
+
     assert changeset.valid?
   end
   test "changeset validates uniqueness of username" do

--- a/test/registrator_test.exs
+++ b/test/registrator_test.exs
@@ -12,16 +12,16 @@ defmodule RegistratorTest do
   @valid_params %{"password" => "secret", "email" => "unique@example.com"}
   @valid_username_params %{"password" => "secret", "username" => "unique@example.com"}
 
-  # test "changeset validates presence of email" do
-  #   changeset = Registrator.changeset(%{})
-  #   assert changeset.errors[:email] == "can't be blank"
-  #
-  #   changeset = Registrator.changeset(%{"email" => ""})
-  #   assert changeset.errors[:email] == "can't be blank"
-  #
-  #   changeset = Registrator.changeset(%{"email" => nil})
-  #   assert changeset.errors[:email] == "can't be blank"
-  # end
+  test "changeset validates presence of email" do
+    changeset = Registrator.changeset(%{})
+    assert changeset.errors[:email] == "can't be blank"
+
+    changeset = Registrator.changeset(%{"email" => ""})
+    assert changeset.errors[:email] == "can't be blank"
+
+    changeset = Registrator.changeset(%{"email" => nil})
+    assert changeset.errors[:email] == "can't be blank"
+  end
 
   test "changeset validates presence of password" do
     changeset = Registrator.changeset(%{"email" => "user@example.com"})

--- a/test/reset_password_test.exs
+++ b/test/reset_password_test.exs
@@ -21,11 +21,11 @@ defmodule ResetPasswordTest do
 
   test "request a reset token" do
     with_mock Mailgun.Client, [send_email: fn _, _ -> {:ok, "response"} end] do
-      Registrator.changeset(%{email: @email, password: "oldpassword"})
+      Registrator.changeset(%{"email" => @email, "password" => "oldpassword"})
       |> Ecto.Changeset.put_change(:confirmed_at, Ecto.DateTime.utc)
-      |> repo.insert
-
+      |> repo.insert!
       conn = call(TestRouter, :post, "/api/password_resets", %{email: @email}, @headers)
+
       assert conn.status == 200
       assert Poison.decode!(conn.resp_body) == "ok"
 
@@ -37,7 +37,7 @@ defmodule ResetPasswordTest do
   test "reset password with a wrong token" do
     {_reset_token, changeset} = Registrator.changeset(%{email: @email, password: "oldpassword"})
     |> PasswordResetter.create_changeset
-    user = repo.insert changeset
+    user = repo.insert! changeset
 
     params = %{user_id: user.id, password_reset_token: "wrong_token", password: "newpassword"}
     conn = call(TestRouter, :post, "/api/password_resets/reset", params, @headers)
@@ -48,7 +48,7 @@ defmodule ResetPasswordTest do
   test "reset password" do
     {reset_token, changeset} = Registrator.changeset(%{email: @email, password: "oldpassword"})
     |> PasswordResetter.create_changeset
-    user = repo.insert changeset
+    user = repo.insert! changeset
 
     params = %{user_id: user.id, password_reset_token: reset_token, password: "newpassword"}
     conn = call(TestRouter, :post, "/api/password_resets/reset", params, @headers)

--- a/test/sign_up_test.exs
+++ b/test/sign_up_test.exs
@@ -40,15 +40,15 @@ defmodule SignUpTest do
     end
   end
 
-  # test "sign up with missing email" do
-  #   conn = call(TestRouter, :post, "/api/users", %{"user" => %{"password" => @password}}, @headers)
-  #   assert conn.status == 422
-  #
-  #   errors = Poison.decode!(conn.resp_body)
-  #   |> Dict.fetch!("errors")
-  #
-  #   assert errors["email"] == "can't be blank"
-  # end
+  test "sign up with missing email" do
+    conn = call(TestRouter, :post, "/api/users", %{"user" => %{"password" => @password}}, @headers)
+    assert conn.status == 422
+
+    errors = Poison.decode!(conn.resp_body)
+    |> Dict.fetch!("errors")
+
+    assert errors["email"] == "can't be blank"
+  end
 
   test "sign up with missing password" do
     conn = call(TestRouter, :post, "/api/users", %{user: %{email: @email}}, @headers)

--- a/test/sign_up_test.exs
+++ b/test/sign_up_test.exs
@@ -40,15 +40,15 @@ defmodule SignUpTest do
     end
   end
 
-  test "sign up with missing email" do
-    conn = call(TestRouter, :post, "/api/users", %{user: %{password: @password}}, @headers)
-    assert conn.status == 422
-
-    errors = Poison.decode!(conn.resp_body)
-    |> Dict.fetch!("errors")
-
-    assert errors["email"] == "can't be blank"
-  end
+  # test "sign up with missing email" do
+  #   conn = call(TestRouter, :post, "/api/users", %{"user" => %{"password" => @password}}, @headers)
+  #   assert conn.status == 422
+  #
+  #   errors = Poison.decode!(conn.resp_body)
+  #   |> Dict.fetch!("errors")
+  #
+  #   assert errors["email"] == "can't be blank"
+  # end
 
   test "sign up with missing password" do
     conn = call(TestRouter, :post, "/api/users", %{user: %{email: @email}}, @headers)

--- a/test/support/ecto_helper.exs
+++ b/test/support/ecto_helper.exs
@@ -24,6 +24,7 @@ defmodule UsersMigration do
   def change do
     create table(:users) do
       add :email,    :text
+      add :username, :text
       add :hashed_password, :text
       add :hashed_confirmation_token, :text
       add :confirmed_at, :datetime
@@ -33,6 +34,7 @@ defmodule UsersMigration do
     end
 
     create index(:users, [:email], unique: true)
+    create index(:users, [:username], unique: true)
   end
 end
 
@@ -47,6 +49,7 @@ defmodule PhoenixTokenAuth.User do
 
   schema "users" do
     field  :email,                       :string
+    field  :username,                    :string
     field  :hashed_password,             :string
     field  :hashed_confirmation_token,   :string
     field  :confirmed_at,                Ecto.DateTime

--- a/test/support/forge.exs
+++ b/test/support/forge.exs
@@ -1,6 +1,6 @@
 defmodule Blacksmith.Config do
   def save(repo, map) do
-    repo.insert(map)
+    repo.insert!(map)
   end
 
   def save_all(repo, list) do

--- a/test/support/forge.exs
+++ b/test/support/forge.exs
@@ -17,6 +17,7 @@ defmodule Forge do
   register(:user,
            __struct__: PhoenixTokenAuth.User,
            email: Sequence.next(:email, &"user#{&1}@example.com"),
+           username: Sequence.next(:username, &"user#{&1}@example.com"),
            hashed_password: PhoenixTokenAuth.Util.crypto_provider.hashpwsalt("secret"),
            confirmed_at: nil
   )

--- a/test/update_account_test.exs
+++ b/test/update_account_test.exs
@@ -17,7 +17,7 @@ defmodule UpdateAccountTest do
   @new_password "secret"
   @headers [{"Content-Type", "application/json"}]
   setup do
-    user = TestRepo.insert(%User{email: @old_email,
+    user = TestRepo.insert!(%User{email: @old_email,
                                  confirmed_at: Ecto.DateTime.utc,
                                  hashed_password: Util.crypto_provider.hashpwsalt(@old_password)})
     token = Authenticator.generate_token_for(user)

--- a/test/update_account_test.exs
+++ b/test/update_account_test.exs
@@ -35,7 +35,7 @@ defmodule UpdateAccountTest do
       conn = call(TestRouter, :put, "/api/account", %{account: %{password: @new_password}}, context.headers)
       assert conn.status == 200
       assert conn.resp_body == Poison.encode!("ok")
-      {:ok, _} = Authenticator.authenticate(@old_email, @new_password)
+      {:ok, _} = Authenticator.authenticate_email(@old_email, @new_password)
 
       assert :meck.num_calls(Mailgun.Client, :send_email, :_, 2) == 0
     end
@@ -46,7 +46,7 @@ defmodule UpdateAccountTest do
       conn = call(TestRouter, :put, "/api/account", %{account: %{email: @new_email}}, context.headers)
       assert conn.status == 200
       assert conn.resp_body == Poison.encode!("ok")
-      {:ok, _} = Authenticator.authenticate(@old_email, @old_password)
+      {:ok, _} = Authenticator.authenticate_email(@old_email, @old_password)
       assert TestRepo.one(User).unconfirmed_email == @new_email
 
       mail = :meck.capture(:first, Mailgun.Client, :send_email, :_, 2)
@@ -62,7 +62,7 @@ defmodule UpdateAccountTest do
       conn = call(TestRouter, :put, "/api/account", %{account: %{email: @old_email}}, context.headers)
       assert conn.status == 200
       assert conn.resp_body == Poison.encode!("ok")
-      {:ok, _} = Authenticator.authenticate(@old_email, @old_password)
+      {:ok, _} = Authenticator.authenticate_email(@old_email, @old_password)
       assert TestRepo.one(User).unconfirmed_email == nil
 
       assert :meck.num_calls(Mailgun.Client, :send_email, :_, 2) == 0
@@ -77,7 +77,7 @@ defmodule UpdateAccountTest do
       conn = call(TestRouter, :put, "/api/account", %{account: %{password: @new_password}}, context.headers)
       assert conn.status == 422
       assert conn.resp_body == Poison.encode!(%{errors: %{password: :too_short}})
-      {:ok, _} = Authenticator.authenticate(@old_email, @old_password)
+      {:ok, _} = Authenticator.authenticate_email(@old_email, @old_password)
       assert :meck.num_calls(Mailgun.Client, :send_email, :_, 2) == 0
     end
   end

--- a/test/update_account_test.exs
+++ b/test/update_account_test.exs
@@ -35,7 +35,7 @@ defmodule UpdateAccountTest do
       conn = call(TestRouter, :put, "/api/account", %{account: %{password: @new_password}}, context.headers)
       assert conn.status == 200
       assert conn.resp_body == Poison.encode!("ok")
-      {:ok, _} = Authenticator.authenticate_email(@old_email, @new_password)
+      {:ok, _} = Authenticator.authenticate_by_email(@old_email, @new_password)
 
       assert :meck.num_calls(Mailgun.Client, :send_email, :_, 2) == 0
     end
@@ -46,7 +46,7 @@ defmodule UpdateAccountTest do
       conn = call(TestRouter, :put, "/api/account", %{account: %{email: @new_email}}, context.headers)
       assert conn.status == 200
       assert conn.resp_body == Poison.encode!("ok")
-      {:ok, _} = Authenticator.authenticate_email(@old_email, @old_password)
+      {:ok, _} = Authenticator.authenticate_by_email(@old_email, @old_password)
       assert TestRepo.one(User).unconfirmed_email == @new_email
 
       mail = :meck.capture(:first, Mailgun.Client, :send_email, :_, 2)
@@ -62,7 +62,7 @@ defmodule UpdateAccountTest do
       conn = call(TestRouter, :put, "/api/account", %{account: %{email: @old_email}}, context.headers)
       assert conn.status == 200
       assert conn.resp_body == Poison.encode!("ok")
-      {:ok, _} = Authenticator.authenticate_email(@old_email, @old_password)
+      {:ok, _} = Authenticator.authenticate_by_email(@old_email, @old_password)
       assert TestRepo.one(User).unconfirmed_email == nil
 
       assert :meck.num_calls(Mailgun.Client, :send_email, :_, 2) == 0
@@ -77,7 +77,7 @@ defmodule UpdateAccountTest do
       conn = call(TestRouter, :put, "/api/account", %{account: %{password: @new_password}}, context.headers)
       assert conn.status == 422
       assert conn.resp_body == Poison.encode!(%{errors: %{password: :too_short}})
-      {:ok, _} = Authenticator.authenticate_email(@old_email, @old_password)
+      {:ok, _} = Authenticator.authenticate_by_email(@old_email, @old_password)
       assert :meck.num_calls(Mailgun.Client, :send_email, :_, 2) == 0
     end
   end


### PR DESCRIPTION
Is the branch refactor the correct branch? 

Rewrote changes from scratch, what is currently working :
- added registration by username ( email still works as before, all tests pass )
- when registering by username, does not send email and auto confirms
- allow to create session by username, sends the reply that simple ember auth expects

I think this patch is better and cleaner, although, the function names/if's could be better.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/manukall/phoenix_token_auth/21)

<!-- Reviewable:end -->
