### PR TITLE
Update mix.exs, config, and tests for ecto 0.14 support

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,8 +2,6 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :my_app, Repo,
-  pool: Ecto.Adapters.SQL.Sandbox
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,8 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :my_app, Repo,
+  pool: Ecto.Adapters.SQL.Sandbox
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,6 +10,7 @@ config :phoenix_token_auth, PhoenixTokenAuth.TestRepo,
   username: "postgres",
   password: "postgres",
   adapter: Ecto.Adapters.Postgres,
+  pool: Ecto.Adapters.SQL.Sandbox,
   url: "ecto://localhost/phoenix_token_auth_test",
   size: 1,
   max_overflow: 0

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule PhoenixTokenAuth.Mixfile do
     [
         {:cowboy, "~> 1.0.0"},
         {:phoenix, ">= 0.14.0"},
-        {:ecto, "~> 0.12.0"},
+        {:ecto, "~> 0.14.0"},
         {:comeonin, "~> 0.10.0"},
         {:postgrex, ">= 0.6.0"},
         {:joken, "~> 0.13.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,7 @@
   "cowlib": {:hex, :cowlib, "1.0.1"},
   "decimal": {:hex, :decimal, "1.1.0"},
   "earmark": {:hex, :earmark, "0.1.17"},
-  "ecto": {:hex, :ecto, "0.12.1"},
+  "ecto": {:hex, :ecto, "0.14.1"},
   "ex_doc": {:hex, :ex_doc, "0.7.3"},
   "faker": {:hex, :faker, "0.5.1"},
   "joken": {:hex, :joken, "0.13.1"},
@@ -15,7 +15,7 @@
   "plug": {:hex, :plug, "0.13.0"},
   "poison": {:hex, :poison, "1.4.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
-  "postgrex": {:hex, :postgrex, "0.8.4"},
+  "postgrex": {:hex, :postgrex, "0.9.1"},
   "ranch": {:hex, :ranch, "1.1.0"},
   "secure_random": {:hex, :secure_random, "0.1.1"},
   "timex": {:hex, :timex, "0.13.4"}}

--- a/test/confirmator_test.exs
+++ b/test/confirmator_test.exs
@@ -6,10 +6,10 @@ defmodule ConfirmatorTest do
 
 
   test "confirmation_needed_changeset adds the hashed token" do
-    {token, changeset} = %Ecto.Changeset{}
+    {token, user} = Forge.user()
       |> Ecto.Changeset.cast(:empty, [], [])
       |> Confirmator.confirmation_needed_changeset()
-    hashed_confirmation_token = Ecto.Changeset.get_change(changeset, :hashed_confirmation_token)
+    hashed_confirmation_token = Ecto.Changeset.get_change(user, :hashed_confirmation_token)
 
     assert crypto_provider.checkpw(token, hashed_confirmation_token)
   end


### PR DESCRIPTION
Update mix.exs ecto, postgrex, and modify config.exs to use ecto's new Sandboxed connection pool.  Also modified `confirmation_needed_changeset` test to pass a dummy user instead of empty changeset to get it to pass properly (not sure if that was "best" decision, though ;))
