### PR TITLE
Possible solution of issue #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Adds token authentication to Phoenix apps using Ecto.
 An example app is available at https://github.com/manukall/phoenix_token_auth_react.
 
 ## Setup
-You need to have a user model with at least the following schema:
+You need to have a user model with at least the following schema and callback:
 
 ```elixir
 defmodule MyApp.User do
@@ -21,6 +21,15 @@ defmodule MyApp.User do
     field  :unconfirmed_email,           :string
     field  :authentication_tokens,       {:array, :string}, default: []
   end
+
+  @required_fields ~w(email)
+  @optional_fields ~w()
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+  end
+
 end
 ```
 

--- a/lib/phoenix_token_auth/registrator.ex
+++ b/lib/phoenix_token_auth/registrator.ex
@@ -9,7 +9,7 @@ defmodule PhoenixTokenAuth.Registrator do
   """
   def changeset(params = %{"username" => username}) when username != "" and username != nil do
     UserHelper.model.changeset(struct(UserHelper.model), params)
-    |> Map.update!(:required, &(~w(username) ++ &1))
+    |> Changeset.cast(params, ~w(username))
     |> Changeset.validate_change(:username, &Util.presence_validator/2)
     |> Changeset.validate_unique(:username, on: Util.repo)
     |> Changeset.put_change(:hashed_confirmation_token, nil)
@@ -19,7 +19,7 @@ defmodule PhoenixTokenAuth.Registrator do
 
   def changeset(params) do
     UserHelper.model.changeset(struct(UserHelper.model), params)
-    |> Map.update!(:required, &(~w(email) ++ &1))
+    |> Changeset.cast(params, ~w(email))
     |> Changeset.validate_change(:email, &Util.presence_validator/2)
     |> Changeset.validate_unique(:email, on: Util.repo)
     |> changeset_helper

--- a/lib/phoenix_token_auth/registrator.ex
+++ b/lib/phoenix_token_auth/registrator.ex
@@ -9,6 +9,7 @@ defmodule PhoenixTokenAuth.Registrator do
   """
   def changeset(params = %{"username" => username}) when username != "" and username != nil do
     UserHelper.model.changeset(struct(UserHelper.model), params)
+    |> Map.update!(:required, &(~w(username) ++ &1))
     |> Changeset.validate_change(:username, &Util.presence_validator/2)
     |> Changeset.validate_unique(:username, on: Util.repo)
     |> Changeset.put_change(:hashed_confirmation_token, nil)
@@ -18,6 +19,7 @@ defmodule PhoenixTokenAuth.Registrator do
 
   def changeset(params) do
     UserHelper.model.changeset(struct(UserHelper.model), params)
+    |> Map.update!(:required, &(~w(email) ++ &1))
     |> Changeset.validate_change(:email, &Util.presence_validator/2)
     |> Changeset.validate_unique(:email, on: Util.repo)
     |> changeset_helper

--- a/lib/phoenix_token_auth/registrator.ex
+++ b/lib/phoenix_token_auth/registrator.ex
@@ -8,7 +8,7 @@ defmodule PhoenixTokenAuth.Registrator do
   Validates that email and password are present and that email is unique.
   """
   def changeset(params = %{"username" => username}) when username != "" and username != nil do
-    Changeset.cast(struct(UserHelper.model), params, ~w(username))
+    UserHelper.model.changeset(struct(UserHelper.model), params)
     |> Changeset.validate_change(:username, &Util.presence_validator/2)
     |> Changeset.validate_unique(:username, on: Util.repo)
     |> Changeset.put_change(:hashed_confirmation_token, nil)
@@ -17,7 +17,7 @@ defmodule PhoenixTokenAuth.Registrator do
   end
 
   def changeset(params) do
-    Changeset.cast(struct(UserHelper.model), params, ~w(email))
+    UserHelper.model.changeset(struct(UserHelper.model), params)
     |> Changeset.validate_change(:email, &Util.presence_validator/2)
     |> Changeset.validate_unique(:email, on: Util.repo)
     |> changeset_helper

--- a/test/support/ecto_helper.exs
+++ b/test/support/ecto_helper.exs
@@ -58,7 +58,7 @@ defmodule PhoenixTokenAuth.User do
     field  :authentication_tokens,       {:array, :string}, default: []
   end
 
-  @required_fields ~w(email)
+  @required_fields ~w()
   @optional_fields ~w()
 
   def changeset(model, params \\ :empty) do

--- a/test/support/ecto_helper.exs
+++ b/test/support/ecto_helper.exs
@@ -57,4 +57,12 @@ defmodule PhoenixTokenAuth.User do
     field  :unconfirmed_email,           :string
     field  :authentication_tokens,       {:array, :string}, default: []
   end
+
+  @required_fields ~w(email)
+  @optional_fields ~w()
+
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+  end
 end


### PR DESCRIPTION
The user schema would be like:

```
schema "users" do
  # Fields required by phoenix-token-auth
  field  :email,                       :string
  field  :hashed_password,             :string
  field  :hashed_confirmation_token,   :string
  field  :confirmed_at,                Ecto.DateTime
  field  :hashed_password_reset_token, :string
  field  :unconfirmed_email,           :string
  field  :authentication_tokens,       {:array, :string}, default: []

  # Custom Fields
  field :team_name, :string

  timestamps
end

@required_fields ~w(email organization_name)
@optional_fields ~w()

@doc """
Creates a changeset based on the `model` and `params`.

If no params are provided, an invalid changeset is returned
with no validation performed.
"""
def changeset(model, params \\ :empty) do
  model
  |> cast(params, @required_fields, @optional_fields)
end
```

As is generated by `mix phoenix.gen.json`.
