### PR TITLE
Bump timex version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule PhoenixTokenAuth.Mixfile do
         {:poison, "~> 1.4.0"},
         {:secure_random, "~> 0.1.0"},
         {:mailgun, "~> 0.1.1"},
-        {:timex, "~> 0.13.0"},
+        {:timex, "~> 0.16.2"},
         # DEV
         {:earmark, "~> 0.1.0", only: :dev},
         {:ex_doc, "~> 0.7.0", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -18,4 +18,5 @@
   "postgrex": {:hex, :postgrex, "0.9.1"},
   "ranch": {:hex, :ranch, "1.1.0"},
   "secure_random": {:hex, :secure_random, "0.1.1"},
-  "timex": {:hex, :timex, "0.13.4"}}
+  "timex": {:hex, :timex, "0.16.2"},
+  "tzdata": {:hex, :tzdata, "0.1.6"}}


### PR DESCRIPTION
I was having some dependency issues with while including phoenix_token_auth in an app already having a newer version of timex.
Bumped timex version to the most recent.
